### PR TITLE
feedback on copy-to-clipboard support

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -45,11 +45,11 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
         wrapper?.appendChild(button);
         wrapper?.appendChild(userMessage);
 
-        button.onclick = () => {
+        button.onclick = async () => {
           let copiedSuccessfully = true;
           try {
             const text = element.textContent || "";
-            navigator.clipboard.writeText(text);
+            await navigator.clipboard.writeText(text);
           } catch (err) {
             console.error(
               "Error when trying to use navigator.clipboard.writeText()",

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -32,7 +32,7 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
         userMessage.textContent = "Copied!";
         span.textContent = "Copy to Clipboard";
 
-        const wrapper: HTMLElement | null = element.parentElement;
+        const wrapper = element.parentElement;
 
         userMessage.setAttribute("class", "user-message");
         userMessage.setAttribute("aria-hidden", "true");

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -17,16 +17,12 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
     if (!doc) {
       return;
     }
-
-    if (!isClipboardSupported()) {
+    if (!navigator.clipboard) {
       console.log(
-        "Copy-to-clipboard disabled because your browser does not appear to support it"
+        "Copy-to-clipboard disabled because your browser does not appear to support it."
       );
-      // bail and don't inject buttons to DOM
       return;
     }
-
-    const clipboard = navigator.clipboard;
 
     [...document.querySelectorAll("div.code-example pre")].forEach(
       (element) => {
@@ -52,17 +48,13 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
         button.onclick = () => {
           let copiedSuccessfully = true;
           try {
-            // If navigator.clipboard is 'undefined' which is falsy
-            // then Clipboard API for whatever reason was undefined so
-            // we can just bail early
-            if (clipboard) {
-              copyToClipboard(element);
-            } else {
-              console.log("Clipboard API is undefined");
-              return; // bail
-            }
+            const text = element.textContent || "";
+            navigator.clipboard.writeText(text);
           } catch (err) {
-            console.error(err);
+            console.error(
+              "Error when trying to use navigator.clipboard.writeText()",
+              err
+            );
             copiedSuccessfully = false;
           }
 
@@ -83,26 +75,4 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
       }
     );
   }, [doc]);
-}
-
-function isClipboardSupported() {
-  const browser = navigator.userAgent;
-  let isSupported = true;
-  // @ts-expect-error
-  const windowClipboard = window.clipboardData;
-
-  if (
-    windowClipboard &&
-    windowClipboard.setData &&
-    browser.indexOf("Microsoft Internet Explorer") > -1
-  ) {
-    // Clipboard Web API is not supported in IE
-    isSupported = false;
-  }
-  return isSupported;
-}
-
-function copyToClipboard(element) {
-  const text = element.textContent || "";
-  navigator.clipboard.writeText(text);
 }


### PR DESCRIPTION
This will now work in Firefox 62 and in Firefox 63. I know, I'm being cryptic. I'm referring to https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard#browser_compatibility 
So if you have Firefox 62, the `Boolean(navigator.clipboard)` will be false (and any version of IE I suppose), but in Firefox 63 it should work. 
Now, by checking if `navigator.clipboard` is not truthy we don't even need to go into `document.querySelectorAll()`.

<img width="1501" alt="Screen Shot 2021-06-04 at 9 16 05 AM" src="https://user-images.githubusercontent.com/26739/120807144-a0effe80-c515-11eb-85fd-1226583f24cf.png">
